### PR TITLE
Added MP as a partner site, but doesn't compile

### DIFF
--- a/WorkPackages/management.tex
+++ b/WorkPackages/management.tex
@@ -16,11 +16,11 @@ once completed)}
   title=Project Management,
   short=Management,
   lead=SRL,
-  MP=1,
-  % QS=1,
-  % IFR=1,
-  % UIO=1,
-  % SRLRM=12,
+  MPRM=1,
+  QSRM=1,
+  IFRRM=1,
+  UIORM=1,
+  SRLRM=12,
   swsites
 ]
 \begin{wpobjectives}

--- a/WorkPackages/management.tex
+++ b/WorkPackages/management.tex
@@ -16,7 +16,7 @@ once completed)}
   title=Project Management,
   short=Management,
   lead=SRL,
-  % MP=1,
+  MP=1,
   % QS=1,
   % IFR=1,
   % UIO=1,


### PR DESCRIPTION
Just to freeze the current state for further investigation:

- this works if MP is the lead site
- the sites are defined in ../proposal.tex
- adding the site to a work package doesn't seem to help

- Error message (for the state of this commit is):
```
make draft

[21]
Overfull \hbox (39.34567pt too wide) in alignment at lines 77--77
 [] [] [] [] [] [] []
(./draft.deliverables

LaTeX Warning: acronym for site XXX undefined on input line 4.

)
Overfull \hbox (17.0336pt too wide) in alignment at lines 77--77
 [] [] [] [] [] [] []

Package longtable Warning: Column widths have changed
(longtable)                in table 3.1.2 on input line 77.

[22] (./milestones.tex) (./WorkPackages/WorkPackages.tex [23]
(./WorkPackages/management.tex

LaTeX Warning: Marginpar on page 24 moved.


./WorkPackages/management.tex:25: Package xkeyval Error: `MP' undefined in fami
lies `workpackage'.

See the xkeyval package documentation for explanation.
Type  H <return>  for immediate help.
 ...

l.25 ]

Output written on draft.pdf (26 pages).
SyncTeX written on draft.synctex.gz.
Transcript written on draft.log.
```
  