### PR TITLE
It is possibl ubuntu:21-10 is not available yet

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: install tex


### PR DESCRIPTION
See https://github.com/actions/virtual-environments

Currently, CI jobs don't run because we wait for a runner to pick up this job.

See https://github.com/minrk/horizon-widera-2022/actions/runs/2039457573 for error message.