### PR TITLE
Check person month metadata 0411

### DIFF
--- a/WorkPackages/applications.tex
+++ b/WorkPackages/applications.tex
@@ -14,15 +14,15 @@ once completed)}
 
 \begin{workpackage}[
   id=applications,
-  wphases=0-36!1,
+  wphases=0-36!0.89,
   swsites,
   title=Applications and use cases,
   short=Applications,
   lead=MP,
-  MPRM=9,
-  SRLRM=9,
+  MPRM=10,
+  SRLRM=3,
   UIORM=8,
-  IFRRM=8
+  IFRRM=11
 ]
 
 \begin{wpobjectives}

--- a/WorkPackages/reproducibility.tex
+++ b/WorkPackages/reproducibility.tex
@@ -6,11 +6,11 @@
 
 \begin{workpackage}[
   id=reproducibility,
-  wphases=0-36!1,
+  wphases=0-36!1.03,
   title=Improving robustness of reproducibility tools,
   short=Core,
   lead=QS,
-  SRLRM=24,
+  SRLRM=23,
   UIORM=0,
   MPRM=2,
   QSRM=12,

--- a/tasks/binder-at-home.tex
+++ b/tasks/binder-at-home.tex
@@ -6,12 +6,12 @@
   % task id for references
   id=binder-at-home,
   % lead institution ID
-  lead=MP,
-  PM=1,
+  lead=SRL,
+  PM=6,
   wphases={0-36},
   % partner institution ID(s)
   % don't include lead here
-  partners={SRL}
+  partners={MP,UIO}
 ]
 In this task, we want to use the compute power of the Desktops of individual researchers and
 users, to recreate software environments in which computational results can be
@@ -30,19 +30,19 @@ It thus possible to overload the system \TODO{Add link to general discussion
 
 To allow the up-scaling of good reproducibility practice, it would be
 desirable not to depend on such a single (or even multiple hosted services).
-  
+
 The compute resources offered through mybinder are modest: at most 2 GB of RAM
 and a single CPU core (\TODO{check this!}).
 Most laptops and Desktops have similar or much better hardware capabilities than
 the mybinder cloud-computing resources currently offer
-  
+
 \paragraph*{Task activity:} Based on the preparations in \WPref{reproducibility} and
 \WPref{impact}, extend Binder so that users of the service can
 carry out the building of the environment, and -- if desired -- launching of a
 notebook server \emph{on their own hardware}. The working title for such
 functionality is ``binder@home'' (as a reference to the crowd-based SETI@home search for
 extraterrestrial intelligence at home.\footnote{https://setiathome.berkeley.edu}
-  
+
 We will design, implement, and test the 'binder@home' functionality, and make it
 available as part of binder software. We will need a utility that takes on
 the responsibility of BinderHub for a single-user use case, and which triggers

--- a/tasks/binder-at-hpc.tex
+++ b/tasks/binder-at-hpc.tex
@@ -6,16 +6,16 @@
   % task id for references
   id=binder-at-hpc,
   % lead institution ID
-  lead=SRL,
-  PM=1,
+  lead=MP,
+  PM=10,
   wphases={0-36},
   % partner institution ID(s)
   % don't include lead here
-  partners={UIO}
+  partners={IFR, UIO}
   ]
 In this task, we want to broaden the applicability of the Binder tools to become
 useful in High Performance Computing (HPC) environments.
-  
+
 \paragraph*{Context:}
 Reproducibility of data created with HPC resources is difficult. In addition to
 a specification and access to the actual (simulation) software and dependencies,
@@ -30,7 +30,7 @@ available.
 It is outside the scope of this proposal to find and implement a generic
 reproducibility approach for HPC use cases. Nevertheless, we propose to explore
 some aspects of HPC-reproducibility already to influence the development of Binder,
-and start the - probably iterative - process of finding a good solution. 
+and start the - probably iterative - process of finding a good solution.
 
 \paragraph*{Strategy:}
 We focus on reproducible execution of an HPC application to compute data as the step of

--- a/tasks/data-publishing.tex
+++ b/tasks/data-publishing.tex
@@ -7,7 +7,7 @@
   id=data-publishing,
   % lead institution ID
   lead=MP,
-  PM=1,
+  PM=11,
   wphases={0-36},
   % partner institution ID(s)
   % don't include lead here
@@ -16,7 +16,7 @@
   The task focuses on the use of reproducible software environments within
   Binder to provide working and interactive code that provides access to a large
   or complex data set.
-  
+
   \paragraph*{Context:} Scientists would like to publish their data. Such a data
   publication must include data set itself, and metadata that explains how to
   interpret the data. In addition to such information, it can improve the
@@ -33,7 +33,7 @@
 
   \paragraph*{Task activity}:
   We will design and implement functionality that allows such data publishing
-  based on Binder tools. 
+  based on Binder tools.
 
   A major challenge is the link to the data: ideally, data sets are hosted on a
   separate infrastructure (such as archives, or files published together with a
@@ -56,4 +56,3 @@
   implementation, to propose a more generic model for the next feature extension
   of the Binder tools.
 \end{task}
-

--- a/tasks/demos.tex
+++ b/tasks/demos.tex
@@ -6,18 +6,18 @@
   % task id for references
   id=demos,
   % lead institution ID
-  lead=SRL,
-  PM=1,
+  lead=MP,
+  PM=5,
   wphases={0-36},
   % partner institution ID(s)
   % don't include lead here
-  partners={UIO}
+  partners={IFR,UIO}
 ]
 
   In this task, we want to demonstrate the value and usefulness of \WPref{reproducibility} and
   \WPref{impact} with real scientific use cases from the research communities involved in \TheProject.
   The demonstrators are designed to exploit the solutions developed within \TheProject (Binder@Home, Binder@HPC, data publishing)
-  and leverage existing institutional and/or national e-infrastructures as well as core EOSC services. 
+  and leverage existing institutional and/or national e-infrastructures as well as core EOSC services.
 
   \begin{compactitem}
   \item FAIR Nordic Earth System Modelling: this science demonstrator leverages Binder@HOME (model development, education, single column or very simple model configuration), Binder@HPC (operational runs at scale including on EuroHPC), data publishing (publication of simulation results from blue-sky research);

--- a/tasks/maintenance.tex
+++ b/tasks/maintenance.tex
@@ -3,7 +3,7 @@
   id=maintenance,
   lead=SRL,
   PM=6,
-  wphases={0-36!.166},
+  wphases={0-36!.17},
   partners={QS}
 ]
 

--- a/tasks/performance-optimisation.tex
+++ b/tasks/performance-optimisation.tex
@@ -7,8 +7,8 @@
   id=performance-optimisation,
   % lead institution ID
   lead=QS,
-  PM=10,
-  wphases={0-36},
+  PM=11,
+  wphases={0-36!0.31},
   % partner institution ID(s)
   % don't include lead here
   partners={SRL}
@@ -20,7 +20,7 @@
   In this task, we will optimise the \repotodocker{} performance.
 
   \TODO{QS - add a little more detail here?}
-  
+
   \TODO{Mention in which deliverable this will be reported?}
   \begin{compactitem}
   \item ...

--- a/tasks/repo2docker.tex
+++ b/tasks/repo2docker.tex
@@ -2,9 +2,9 @@
   title=repo2docker development,
   id=repo2docker-timemachine,
   lead=SRL,
-  PM=38,
-  wphases={0-36!1.055},
-  partners={QS,MP}
+  PM=10,
+  wphases={0-36!0.28},
+  partners={QS}
 ]
 
 Often, a repository of scientific results may
@@ -29,7 +29,7 @@ be specified at all.
 In this task, we will teach \repotodocker{} to establish the date of publication
 (or last modification) of the repository, to determine the appropriate version
 of software libraries from that time, and to select libraries with those
-versions if no specific version is specified. 
+versions if no specific version is specified.
 
 In the context of Python packages, we can use the
 \softwarename{pypi-timemachine}
@@ -37,4 +37,3 @@ package.\footnote{\url{https://github.com/astrofrog/pypi-timemachine}}.
 
 \TODO{@QS, @min - Comment on other software sources - conda, ... ?}
 \end{task}
-

--- a/tasks/study.tex
+++ b/tasks/study.tex
@@ -7,8 +7,8 @@
   id=repo2docker-checker,
   % lead institution ID
   lead=SRL,
-  PM=12,
-  wphases={0-24},
+  PM=10,
+  wphases={0-24!0.28},
   % partner institution ID(s)
   % don't include lead here
   partners={MP}
@@ -52,7 +52,7 @@ The task includes the following activities:
     repositories.
   \item Automate the analysis of the results, so the study can be repeated later.
   \end{compactitem}
-  
+
   The tool will be made available as open source
   (\localdelivref{deliv-id-repo2docker-checker-software}). Some of the findings
   here will contribute to the \TODO{deliverable XXX in WP5 - best practice for


### PR DESCRIPTION
As of now, this merge request checks and fixes the person-months for WP2 and WP4 as there is an 1:1 correspondence between the TeX documents and the person-months spreadsheet. (This is not the case for WP1 and WP3, probably due to work-in-progress, so this needs to be checked later.)