### PR TITLE
fix white space typo leading to weird character in PDF output

### DIFF
--- a/objectives-and-ambition.tex
+++ b/objectives-and-ambition.tex
@@ -318,7 +318,8 @@ and they can be described as having a different TRL \emph{in different contexts}
 
 The Binder software and service demonstration at mybinder.org is TRL 6,
 where scope \emph{excludes} long-term robustness.
-The Binder software for deploying services with authenticated access to data is TRL 3.
+The Binder software for deploying services with authenticated access to data is TRL 3.
 We will bring it to TRL 5 or 6.
 The Binder tool repo2docker when targeting robust reproducible environments is TRL 4.
 We will bring it to TRL 6.
+


### PR DESCRIPTION
There was "more than a blank" (i.e. other bytes) between the words "access to" which caused a weird character in the PDF output (on TeX Live 2021). Now it is a true blank.