### PR TITLE
Formatting fixes

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -3,7 +3,7 @@ $pdf_previewer = 'open -a Skim';
 @generated_exts = (@generated_exts, 'synctex.gz');
 $latex = 'latex -synctex=1 -interaction=nonstopmode -shell-escape';
 $pdflatex = 'pdflatex -synctex=1 -interaction=nonstopmode -shell-escape';
-$xelatex = 'xelatex -synctex=1 -interaction=nonstopmode';
+$xelatex = 'xelatex -synctex=1 -interaction=nonstopmode -shell-escape';
 $pdf_mode = 5;
 @default_files = ('draft.tex');
 $max_repeat=5;

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:21.10
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get -y install \
-            --no-install-recommends \
             ca-certificates \
             make \
             latexmk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get -y install \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TBIB.pdf 	= $(TBIB:%.tex=%.pdf)         	  # PDFs to be produced
 TBIB.aux 	= $(TBIB:%.tex=%.aux)             # their aux files.
 PDATA 		= $(PROPOSAL:%.tex=%.pdata)       # the proposal project data
 SRC = $(filter-out $(TARGET),$(shell ls *.tex */*.tex))   # included files
-PDFLATEX = xelatex -interaction scrollmode -file-line-error -halt-on-error -synctex=1
+PDFLATEX = xelatex -interaction scrollmode -file-line-error -halt-on-error -synctex=1 -shell-escape
 BBL = $(PROPOSAL:%.tex=%.bbl)
 PROPCLS.dir = $(PROP.dir)/base
 PROPETC.dir = $(PROP.dir)/etc

--- a/WorkPackages/WorkPackages.tex
+++ b/WorkPackages/WorkPackages.tex
@@ -1,4 +1,4 @@
-\newpage
+\draftpage
 \subsubsection{Work Package Descriptions}\label{sec:workpackages}
 %%% work package style may be broken -- fix this!!
 
@@ -21,15 +21,15 @@
 %% Local WP number counter - should possibly be global and hidden?
 \begin{workplan}
 \input{WorkPackages/management}
-\newpage
+\draftpage
 \input{WorkPackages/reproducibility}
-\newpage
+\draftpage
 \input{WorkPackages/impact}
-\newpage
+\draftpage
 \input{WorkPackages/applications}
-\newpage
+\draftpage
 \input{WorkPackages/education}
-\newpage
+\draftpage
 \end{workplan}
 
 \ifgrantagreement

--- a/consortium.tex
+++ b/consortium.tex
@@ -118,8 +118,7 @@ work together within the interdisciplinary team of participants.
 
 \subsubsection{Capacities and roles of participants}
 
-\paragraph{Simula Research Laboratory}
-
+\noindent \textbf{Simula Research Laboratory}
 \site{SRL} is an internationally-leading Norwegian research institute in the key
 ICT areas: communication systems, scientific computing, and software
 engineering. Dedicated to tackling scientific challenges with long-term impact and of
@@ -145,7 +144,7 @@ and for project-wide administrative support,
 as well as the host of some project activities such as workshops,
 and cloud computing resources.
 
-\paragraph{Max Planck Gesellschaft}
+\noindent \textbf{Max Planck Gesellschaft}
 The Max Planck Society (MPG) is non-profit research
 organisation with 86 research institutes and nearly 24,000 staff. For this
 project, we have Max Planck representatives from the Max Planck Computing and Data
@@ -183,8 +182,7 @@ activities of scientists in the Max Planck Society -- including social sciences,
 humanities and HPC-based activities -- to evaluate, improve and apply the Binder
 tools for use cases such as data publishing and better reproducibility in HPC.
 
-\paragraph{QuantStack}
-
+\noindent \textbf{QuantStack}
 QuantStack is a France-based software corporation specializing in open-source
 scientific computing.
 
@@ -210,14 +208,13 @@ the development of the mamba package manager, which has been adopted by the cond
 and Binder projects, among others.
 
 Clients and partners of QuantStack range from financial software companies to robotics
-startups and public research institutions. 
+startups and public research institutions.
 
 QuantStack's team will provide expertise to the consortium as core Jupyter developers,
 and will contribute to the project by improving the performance and reliability of the
 Binder project for building software environments.
 
-\paragraph{Ifremer}
-
+\noindent \textbf{Ifremer}
 Ifremer, French National Institute for Ocean Science, is a French public
 scientific and technological institution that works for exploring, understanding
 and predicting the ocean. A pioneer in ocean science, Ifremer's cutting-edge
@@ -231,8 +228,7 @@ applying the developed
 tools for practical reproducibility in real-world research contexts.
 \TODO{Tina, a bit more detail on the use cases, and the challenges?}
 
-\paragraph{University of Oslo}
-
+\noindent \textbf{University of Oslo}
 The University of Oslo (UiO) is Norway's oldest institution for research and
 higher education, with 28,000 students and 6,000 employees. UiO aspires to be an
 international hub for the research-based integration of computing into science
@@ -250,12 +246,12 @@ initiative that acts as a hub for FAIR (Findable, Accessible, Interoperable, and
 Reusable) software practices. Twice a year, CodeRefinery organizes big online
 training events with more then 300 attendees each.
 
-The focus of UiO is to use their vast and leading experience in training 
+The focus of UiO is to use their vast and leading experience in training
 and communication to educate researchers globally about open science and
 practical reproducibility, to help translate the technical advances of this
 project into wide-spread impact.
 
-\TODO{Anne - is this an okay description?} 
+\TODO{Anne - is this an okay description?}
 
 \subsubsection{Connections beyond project partners}
 
@@ -270,7 +266,7 @@ to also be able to use that network to support communication, dissemination and
 exploitation of our results.
 
 The project partners are research active in current topics of open science, and
-are members in various of research activities and organisations, including 
+are members in various of research activities and organisations, including
 BIGMax, NOMAD, FAIRmat, DICE, and Software Sustainability Institute (SSI).
 
 \TODO{All, Please list more. Feel free to add more relevant ones at the beginning.

--- a/excellence.tex
+++ b/excellence.tex
@@ -51,7 +51,7 @@ goal is to \textbf{improve the accessibility, interactivity,
 
 \end{draft}
 
-\clearpage
+\draftpage
 
 %%% Local Variables:
 %%% mode: latex

--- a/impact.tex
+++ b/impact.tex
@@ -656,22 +656,20 @@ maximise its impact.
 
 \textbf{KEY ELEMENT OF THE IMPACT SECTION}
 
-\newlength{\savedparindent}
-\newcommand{\summarybox}[2]{
-\begin{framed}
+% measured original color as 0, 0.75, 0.95
+% but it's a bit low-contrast
 
-\centerline{\textbf{ #1}}
-\setlength{\savedparindent}{\parindent}
-\par
-\setlength{\parindent}{0pt}
-{#2}
-\setlength{\parindent}{\savedparindent}
-\end{framed}
+\definecolor{summaryblue}{rgb}{0, 0.7, 0.9}
+\newtcolorbox{summarybox}[1]{
+    colback=white,
+    colframe=summaryblue,
+    fonttitle=\bfseries,
+    title={#1}
 }
 
-
 \begin{multicols}{2}
-\summarybox{SPECIFIC NEEDS}{
+
+\begin{summarybox}{SPECIFIC NEEDS}
 \eucommentary{What are the specific needs that triggered this project?}
 
 Reproducibility is a widely recognized challenge in computational science.
@@ -681,8 +679,9 @@ which may not be practical or desirable across a variety of domains or communiti
 Reliably reproducing software environments without requiring adoption of any single tool chain
 allows for modular adoption, integrating into policies, practices, etc.
 We want to lower the practical barrier to reproducibility, and thereby increase the adoption of reproducible practices.
-}
-\summarybox{D \& E \& C MEASURES}{
+\end{summarybox}
+
+\begin{summarybox}{D \& E \& C MEASURES}
 \eucommentary{What dissemination, exploitation and communication measures will you apply to the results?}
 
 \textbf{Exploitation:} All services based on BinderHub will immediately benefit from the project, improving tools
@@ -704,10 +703,9 @@ industrial robotics and quantitative finance.
   about the project through news releases, videos, a website, social media,
   further media engagement, fliers and interviews, with a consistent visual
   identity.
+\end{summarybox}
 
- }
-
-\summarybox{EXPECTED RESULTS}{
+\begin{summarybox}{EXPECTED RESULTS}
 \eucommentary{What do you expect to generate by the end of the project? }
 
 \textbf{Improved software tools for reproducing computational environments}:
@@ -715,9 +713,10 @@ by improving the Binder tools for reproducible environments,
 it will be easier for researchers to produce and share results openly and reproducibly.
 
 \textbf{Improved understanding of good practices for reproducibility}: study results, documentation, and workshops will aid researchers and policy makers in understanding the most appropriate practices to adopt in their pursuit of reproducible research.
-}
 
-\summarybox{TARGET GROUPS}{
+\end{summarybox}
+
+\begin{summarybox}{TARGET GROUPS}
 \eucommentary{Who will use or further up-take the results of the project? Who will benefit from the results of the project?}
 
 \textbf{Computational science practitioners}: researchers with an interest in reproducibility of their on work.
@@ -727,9 +726,9 @@ it will be easier for researchers to produce and share results openly and reprod
 \textbf{Policy makers}: Funders and institutions requiring their subjects to follow reproducible practices
 
 \textbf{Publishers}: Requiring/enabling reproducible publications
-}
+\end{summarybox}
 
-\summarybox{OUTCOMES}{
+\begin{summarybox}{OUTCOMES}
 \eucommentary{What change do you expect to see after successful dissemination and exploitation of project results to the target group(s)?}
 
 \textbf{Adoption of Binder tools for reproducibility}:
@@ -737,8 +736,8 @@ practitioners will have access to Binder tools for reproducibility.
 Having improved their usability and robustness
 
 \textbf{Facilitating practical policies for reproducible publications}
-}
-\summarybox{IMPACTS}{
+\end{summarybox}
+\begin{summarybox}{IMPACTS}
 \eucommentary{
 What are the expected wider scientific, economic and societal effects of the project contributing to the expected impacts outlined in the respective destination in the work programme?
 }
@@ -749,8 +748,7 @@ access of reproducible research outputs.
 
 \textbf{Increased re-use of scientific results}: Practical reproducibility
 enables rapid re-use of published results leading to more effective research activities.
-
-}
+\end{summarybox}
 \end{multicols}
 
 % \noindent

--- a/impact.tex
+++ b/impact.tex
@@ -652,9 +652,8 @@ We will continually refine our Communication, Dissemination, and Exploitation pl
 Provide a summary of this section by presenting in the canvas below the
 key elements of your project impact pathway and of the measures to
 maximise its impact.
+KEY ELEMENT OF THE IMPACT SECTION
 }
-
-\textbf{KEY ELEMENT OF THE IMPACT SECTION}
 
 % measured original color as 0, 0.75, 0.95
 % but it's a bit low-contrast
@@ -750,6 +749,7 @@ access of reproducible research outputs.
 enables rapid re-use of published results leading to more effective research activities.
 \end{summarybox}
 \end{multicols}
+\clearpage
 
 % \noindent
 % \fbox{

--- a/impact.tex
+++ b/impact.tex
@@ -364,7 +364,7 @@ There are at least 8 million notebooks deposited on GitHub \cite{notebookcount},
 the size of the Notebook user base was estimated to be of the order of
 millions in 2015 \cite{jupyter-grant}. We know that the public Binder-based service mybinder.org
 was used to create over 10,000,000 computational environments
-from at least 50,000 unique repositories in 2021 (Section~\ref{sec:mybinder}).
+from at least 50,000 unique repositories in 2021~(Section~\ref{sec:mybinder}).
 
 \TODO{Or integrate into table above?}
 \TODO{This is mentioned on the evaluation form for this section, and then

--- a/objectives-and-ambition.tex
+++ b/objectives-and-ambition.tex
@@ -70,7 +70,7 @@ Objectives should be SMART: Specific, Measurable, Achievable, Relevant, Time-bou
   \label{tab:objectives-tasks}
   \caption{
   Our objectives and their relationship to the work programme}
-  \begin{tabular}{>{\raggedright}m{.2\textwidth}|m{.4\textwidth}|m{.4\textwidth}}
+  \begin{tabular}{>{\raggedright}m{.2\textwidth}|m{.36\textwidth}|m{.36\textwidth}}
 
     \hline
 

--- a/preamble.tex
+++ b/preamble.tex
@@ -2,7 +2,6 @@
 \usepackage{comments}
 % %\usepackage[final]{comments}
 \usepackage{fontspec}
-\usepackage{ifplatform}
 \usepackage{verbatim}
 \usepackage{listings}
 \usepackage{supertabular,array}
@@ -81,10 +80,8 @@
 \newcommand{\Julia}{\software{Julia}}
 \newcommand{\Fortran}{\software{Fortran}}
 
-\XeTeXtracingfonts=1\relax
+\XeTeXtracingfonts=1
 
-\ifmacosx
-\setmainfont{Times New Roman}
-\else
-\setmainfont{Nimbus Roman No9 L}
-\fi
+% this is latex's Times New Roman,
+% extending Nimbus Roman No9 L
+\setmainfont{texgyretermes-regular.otf}

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,6 +1,8 @@
 \usepackage{lscape} % for landscape
 \usepackage{comments}
 % %\usepackage[final]{comments}
+\usepackage{fontspec}
+\usepackage{ifplatform}
 \usepackage{verbatim}
 \usepackage{listings}
 \usepackage{supertabular,array}
@@ -79,7 +81,10 @@
 \newcommand{\Julia}{\software{Julia}}
 \newcommand{\Fortran}{\software{Fortran}}
 
-%%% Local Variables:
-%%% mode: latex
-%%% TeX-master: "proposal"
-%%% End:
+\XeTeXtracingfonts=1\relax
+
+\ifmacosx
+\setmainfont{Times New Roman}
+\else
+\setmainfont{Nimbus Roman No9 L}
+\fi

--- a/preamble.tex
+++ b/preamble.tex
@@ -4,6 +4,7 @@
 \usepackage{verbatim}
 \usepackage{listings}
 \usepackage{supertabular,array}
+\usepackage{tcolorbox}
 \makeatletter
 \newcommand\arraybslash{\let\\\@arraycr}
 \makeatother

--- a/proposal.tex
+++ b/proposal.tex
@@ -151,7 +151,7 @@
 - [ ] describe our relation to the Binder team
 
 \end{draft}
-\clearpage
+\draftpage
 
 \begin{proposal}[
   % participants
@@ -237,7 +237,7 @@
 \ifsubmit
 \else
 % only abstract in draft
-\clearpage
+\draftpage
 \input{abstract}
 
 % detailed toc in draft
@@ -275,16 +275,15 @@ Please bear in mind that advances beyond the state of the art must be interprete
 % ---------------------------------------------------------------------------
 %  Section 1.2: Methodology
 % ---------------------------------------------------------------------------
-\clearpage
+\draftpage
 \input{concept.tex}
 
 % ---------------------------------------------------------------------------
 %  Section 2: Impact
 %  ---------------------------------------------------------------------------
-\clearpage
+\draftpage
 \input{impact.tex}
-
-\clearpage
+\draftpage
 
 % ---------------------------------------------------------------------------
 %  Section 3: Implementation
@@ -298,11 +297,6 @@ Please bear in mind that advances beyond the state of the art must be interprete
 
 \label{sect:workplan}
 \input{workplan}
-\newpage
-
-% management structure is removed, though some content may want to move
-% # to workplan.tex
-% \input{management_structure_and_procedures.tex}
 
 \draftpage
 \subsection{Capacity of participants and consortium as a whole}

--- a/proposal.tex
+++ b/proposal.tex
@@ -184,7 +184,7 @@
   UIOcountry=Norway,
   % site=XXX, % template example
   % alternative: (can be combined)
-  coordinator=Dr. Benjamin Ragan-Kelley,
+  coordinator=Simula Research Laboratory,
   Cemail=benjaminrk@simula.no,
   Ctelfax=(47) XXX-XX-XXX,
   %coordinatorsite=SRL,

--- a/proposal.tex
+++ b/proposal.tex
@@ -21,6 +21,7 @@
 %%
 
 \documentclass[
+  11pt,
   deliverables,
   longtasklabels,
   numericcites,
@@ -81,8 +82,11 @@
 
 
 \begin{document}
-\begin{draft}
 
+% satisfy fancyhdr with 11pt
+\setlength{\headheight}{13.6pt}
+
+\begin{draft}
 
 \section*{Guidelines for proposal co-authors}
 

--- a/resources.tex
+++ b/resources.tex
@@ -4,7 +4,7 @@
 % -	a table showing justifications for purchase costs (table 3.1h) for participants where those costs exceed 15% of the personnel costs (according to the budget table in proposal part A);
 % -	if applicable, a table showing justifications for other costs categories (table 3.1i);
 % -	if applicable, a table showing in-kind contributions from third parties (table 3.1j)
-\clearpage
+\draftpage
 \subsubsection{Resources to be Committed}\label{sec:resources}
 
 Tables summarizing effort and costs are presented here.


### PR DESCRIPTION
- match template style more closely in summary with tcolorbox
- use correct minimum (larger) font sizes
- compact larger output by removing all page breaks in final

I think we should probably save at least 2 pages in our "Terminology" section by culling details, at which point we can have some page breaks back.