### PR TITLE
Revert "simpler way to get latex Times New Roman"

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -2,6 +2,7 @@
 \usepackage{comments}
 % %\usepackage[final]{comments}
 \usepackage{fontspec}
+\usepackage{ifplatform}
 \usepackage{verbatim}
 \usepackage{listings}
 \usepackage{supertabular,array}
@@ -80,8 +81,10 @@
 \newcommand{\Julia}{\software{Julia}}
 \newcommand{\Fortran}{\software{Fortran}}
 
-\XeTeXtracingfonts=1
+\XeTeXtracingfonts=1\relax
 
-% this is latex's Times New Roman,
-% extending Nimbus Roman No9 L
-\setmainfont{texgyretermes-regular.otf}
+\ifmacosx
+\setmainfont{Times New Roman}
+\else
+\setmainfont{Nimbus Roman No9 L}
+\fi

--- a/preamble.tex
+++ b/preamble.tex
@@ -83,8 +83,8 @@
 
 \XeTeXtracingfonts=1\relax
 
-\ifmacosx
-\setmainfont{Times New Roman}
-\else
-\setmainfont{Nimbus Roman No9 L}
-\fi
+% \ifmacosx
+% \setmainfont{Times New Roman}
+% \else
+% \setmainfont{Nimbus Roman No9 L}
+% \fi


### PR DESCRIPTION
This reverts commit 32fb68e0984fac364392924a954f60838c813ee8.

I found (after merging) that PR #59 removes all boldface. Undoing this commit seems to resolve the issue.