### PR TITLE
We refer to the repo2docker section repeatedly (12 times)

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -517,6 +517,10 @@ Zenodo, Hydroshare, Figshare, and Dataverse.
 For the automatic building of reproducible computational environments,
 \repotodocker{} understands commonly used conventions for environment specifications and
 community standard tools such as Docker, conda, mamba, and pip.
+The
+documentation\footnote{\url{https://repo2docker.readthedocs.io/en/latest/config_files.html}}
+  contains a full list.
+
 \repotodocker{} is successful enough to be widely adopted,
 but many shortcomings have been identified,
 especially when a repository contains an \emph{incomplete} specification.


### PR DESCRIPTION
throughout the proposal, and multiple times make reference to the list of
currently supported configuration files. Thus, I think it would be good to give
the interested reader the option to look at those in detail.