### PR TITLE
improve layout and presentation of consortium

### DIFF
--- a/consortium.tex
+++ b/consortium.tex
@@ -120,7 +120,7 @@ work together within the interdisciplinary team of participants.
 \subsubsection{Capacities and roles of participants}
 
 \noindent \textbf{Simula Research Laboratory}
-\site{SRL} is an internationally-leading Norwegian research institute in the key
+(\site{SRL}) is an internationally-leading Norwegian research institute in the key
 ICT areas: communication systems, scientific computing, and software
 engineering. Dedicated to tackling scientific challenges with long-term impact and of
 genuine importance to real life, Simula offers an environment that emphasises
@@ -145,15 +145,15 @@ and for project-wide administrative support,
 as well as the host of some project activities such as workshops,
 and cloud computing resources.
 
-\noindent \textbf{Max Planck Gesellschaft}
-The Max Planck Society (MPG) is non-profit research
+\medskip \noindent The \textbf{Max Planck Society}
+(Max Planck Gesellschaft, MPG) is non-profit research
 organisation with 86 research institutes and nearly 24,000 staff. For this
-project, we have representatives from the Max Planck Computing and Data
-Facility (MPCDF) -- the organisation's cross-institutional competence centre
-for computational and data sciences -- and staff from the Max Planck Institute
-for Structure and Dynamics of matter (MPSD), who are active in condensed matter research and
+project, we have representatives from the \textbf{Max Planck Computing and Data
+Facility (MPCDF)} -- the organisation's cross-institutional competence centre
+for computational and data sciences -- and staff from the \textbf{Max Planck Institute
+for Structure and Dynamics of Matter (MPSD)}, who are active in condensed matter research and
 reproducibility research.
-%
+
 The MPCDF operates large state-of-the-art supercomputers, several mid-range
 compute systems and data repositories for various Max Planck institutes and
 provides an up-to-date infrastructure for data management including long-term
@@ -164,22 +164,23 @@ such as Big data driven material science (BIGMax), FAIR data infrastructure for
 Condensed-Matter Physics and the Chemical Physics of Solids (FAIRmat), and Data
 Infrastructure Capacity for EOSC (DICE).
 
+MPCDF and MPSD have long-standing experience in delivering training and
+workshops on computational methods, including best practice and reproducibility.
 % A bit odd to mention an individual here, but lots of the prior work
 % was not done at MPG, so it may help reviewers to know the name.
-One team member (Hans Fangohr) has a long-standing collaboration with \site{SRL}
+One team member (Hans Fangohr, MPSD) has a long-standing collaboration with \site{SRL}
 and the Jupyter project, and a research interest in the use of open source
 tools, Jupyter, and Binder for research and reproducible
 research~\cite{Fangohr:ICALEPCS2017-TUCPA01,Fangohr2020,nbval-arxiv,Beg2021}.
+% not sure if we want to show case the following:
+% https://fangohr.github.io/teaching/index.html#awards
+Moreover,
+Hans Fangohr has won awards repeatedly for excellence in design and delivery of
+teaching activities at different universities.
+%
 The MPCDF has multi-year expertise in deploying and using Cloud-based
 JupyterHub and BinderHub installations for various use cases from different
 scientific domains.
-
-MPCDF and MPSD have long standing experience in delivering training and
-workshops on computational methods, including best practice and reproducibility.
-% not sure if we want to show case the following:
-Hans Fangohr has won awards repeatedly for excellence in design and delivery of
-teaching activities at different universities.
-% https://fangohr.github.io/teaching/index.html#awards
 
 In this project, the team will co-design Binder-based services for
 reproducible science and data publishing. They will draw from the wide research
@@ -187,9 +188,11 @@ activities of scientists in the Max Planck Society -- including social sciences,
 humanities and HPC-based activities -- to evaluate, improve and apply the Binder
 tools for use cases such as data publishing and better reproducibility in HPC.
 
-\noindent \textbf{QuantStack}
-QuantStack is a France-based software corporation specialising in open-source
+\medskip \noindent \textbf{QuantStack}
+is a France-based software corporation specialising in open-source
 scientific computing.
+Clients and partners of QuantStack range from financial software companies to robotics
+startups and public research institutions.
 
 QuantStack's team of open-source developers comprises maintainers and contributors
 to open-source technologies considered industry standards and adopted by millions
@@ -212,15 +215,12 @@ and hundreds of millions of package downloads monthly. We are also responsible f
 the development of the mamba package manager, which has been adopted by the conda-forge
 and Binder projects, among others.
 
-Clients and partners of QuantStack range from financial software companies to robotics
-startups and public research institutions.
-
 QuantStack's team will provide expertise to the consortium as core Jupyter developers,
 and will contribute to the project by improving the performance and reliability of the
 Binder project for building software environments.
 
-\noindent \textbf{Ifremer}
-Ifremer, French National Institute for Ocean Science, is a French public
+\medskip \noindent
+The \textbf{French National Institute for Ocean Science (Ifremer)}, is a French public
 scientific and technological institution that works for exploring, understanding
 and predicting the ocean. A pioneer in ocean science, Ifremer's cutting-edge
 research is grounded in sustainable development and open science. Ifremer's
@@ -233,8 +233,8 @@ applying the developed
 tools for practical reproducibility in real-world research contexts.
 \TODO{Tina, a bit more detail on the use cases, and the challenges?}
 
-\noindent \textbf{University of Oslo}
-The University of Oslo (UiO) is Norway's oldest institution for research and
+\medskip \noindent The \textbf{University of Oslo}
+(UiO) is Norway's oldest institution for research and
 higher education, with 28,000 students and 6,000 employees. UiO aspires to be an
 international hub for the research-based integration of computing into science
 education and has financed a university-wide hosting service for Jupyter


### PR DESCRIPTION
Rather than starting with bold face text for the instition's name
the name and abbreviation are now in bold face but integrated into
the text. Moreover, some reordering was done to avoid unecessary
paragraphs.