### PR TITLE
some fixes to colon and comma use

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -121,7 +121,7 @@ simulations.
 We can classify the reproducibility challenges listed above into different categories:
 
 \begin{description}
-\item[1. Workflow]: Are the processing commands (and their order)
+\item[1. Workflow:] Are the processing commands (and their order)
 \textbf{correctly recorded}? Do we know which part of the dataset the analysis is meant to be applied to? Do we know the protocol, \emph{i.e.} are the different processing steps for that data recorded? This could be the order in which analysis scripts need to be executed -- for example to compute intermediate results -- which will be turned into a figure in the last step?
 
 We will call this sequence of steps the \myemph{workflow}. This is to a significant degree a question of the organisation and documentation of the research process. This workflow could be archived -- for example -- through a \softwarename{README} file, or scanned pages of a hand-written laboratory notebook as a pdf file, or as a
@@ -131,7 +131,7 @@ This is particularly challenging where software is used which can only be
 controlled via a Graphical User Interface, as it may require manual recording
 and description of the different clicks and steps in a laboratory logbook.
 
-\item[2. Software environment]: Can we \textbf{recreate the software environment} that is required to execute these commands?
+\item[2. Software environment:] Can we \textbf{recreate the software environment} that is required to execute these commands?
 \begin{itemize}
 \item Where software is involved, have we recorded which version of that software is needed (or was used)? If compilation is required, do we know which compilers (and which version) and which additional dependencies are required?
 \item Are there instructions on how to obtain / compile the required dependencies,
@@ -139,12 +139,12 @@ and the software itself (in particular where this is about simulation-based
 science or more complex analysis and interpretation software tools)?
 \end{itemize}
 
-\item[3. Importance]: Is the researcher convinced that investing effort into making
+\item[3. Importance:] Is the researcher convinced that investing effort into making
 their work more reproducible is a \textbf{worthwhile investment}? This is a wide topic,
 touching on expectations, existing cultures, lack of metrics that acknowledge
 reproducibility efforts, and policies.
 
-\item[4. Other]: There are other related topics, for example the challenge of
+\item[4. Other:] There are other related topics, for example the challenge of
 archival of (large) research datasets, of making the data FAIR, and strict
 (important for some domains) bit-wise reproducibility.
 \end{description}

--- a/consortium.tex
+++ b/consortium.tex
@@ -147,7 +147,7 @@ as well as the host of some project activities such as workshops,
 and cloud computing resources.
 
 \medskip \noindent The \textbf{Max Planck Society}
-(Max Planck Gesellschaft, MPG) is non-profit research
+(Max Planck Gesellschaft, MPG) is a non-profit research
 organisation with 86 research institutes and nearly 24,000 staff. For this
 project, we have representatives from the \textbf{Max Planck Computing and Data
 Facility (MPCDF)} -- the organisation's cross-institutional competence centre
@@ -227,7 +227,7 @@ and will contribute to the project by improving the performance and reliability 
 Binder project for building software environments.
 
 \medskip \noindent
-The \textbf{French National Institute for Ocean Science (Ifremer)}, is a French public
+The \textbf{French National Institute for Ocean Science (Ifremer)} is a French public
 scientific and technological institution that works for exploring, understanding
 and predicting the ocean. A pioneer in ocean science, Ifremer's cutting-edge
 research is grounded in sustainable development and open science. Ifremer's


### PR DESCRIPTION
This fixes the location of the colons in the list of section 1.2.3
which were floating between the list labels and the following text.
It also removes a wrong comma in the ifremer text and adds a missing
`a`  to max planck.