### PR TITLE
finalise page layout impact section

### DIFF
--- a/impact.tex
+++ b/impact.tex
@@ -2,7 +2,7 @@
 %  Section 2: Impact
 % ---------------------------------------------------------------------------
 
-
+\clearpage
 \section{Impact}
 \label{sec:impact}
 
@@ -82,9 +82,10 @@ The expected outputs and impact of \TheProject with respect to the
 work program is detailed in Tables~\ref{table:output-comparison}
 and~\ref{table:impact-comparison}, respectively.
 
+%\begin{table}[p]
 \begin{table}[h!]
   \begin{center}
-    \begin{tabular}{>{\raggedright}m{.475\textwidth}|m{.475\textwidth}}
+    \begin{tabular}{>{\raggedright}m{.30\textwidth}|m{.65\textwidth}}
       \toprule
       \textbf{Expected outputs from call}
       & \textbf{Expected outputs from the \TheProject project}\\\midrule
@@ -129,7 +130,7 @@ and~\ref{table:impact-comparison}, respectively.
 
 \begin{table}[h!]
   \begin{center}
-    \begin{tabular}{>{\raggedright}m{.25\textwidth}|m{.7\textwidth}}
+      \begin{tabular}{>{\raggedright}m{.2\textwidth}|m{.75\textwidth}}
       \toprule
       \textbf{Expected impacts from call}
       & \textbf{Expected impacts from the \TheProject project}\\\midrule
@@ -188,20 +189,19 @@ and~\ref{table:impact-comparison}, respectively.
   \caption{Relating \TheProject impacts to the impacts expected by the call \label{table:impact-comparison}}
 \end{table}
 
-
-\newpage
+%\newpage
 \subsubsection{Measuring impact}\label{sec:KPIs}
 
 As we are building tools for open and reproducible science, the best measure of our impact
 is in the adoption and use of these tools and services based on them. This can be observed
 qualitatively (anecdotal feedback and case studies) and quantitatively (counting workshop
-attendees, for example).\medskip
-
+attendees, for example).
+%
 % Much of our work will be in the form of contributions to existing
 % public projects, such as Binder and Jupyter, which can be measured in our participation in
 % those projects, such as code and documentation contributions, bug reports, and roadmap
 % contributions.
-
+%
 We measure progress toward our objectives (Table~\ref{tab:objectives-tasks})
 via the following Key Performance Indicators (KPIs):
 \begin{compactenum}[\textbf{KPI} 1:]


### PR DESCRIPTION
- start impact section on new page
- make tables a bit shorter (by adjusting column width to content)
- KPI section now fits nicely on one page (page 18), (removed one empty line)
- the important section 2.1.3 target groups and scale of impact now features nicely at the top of o page

Both KPI and the scale of impact where scattered across multiple pages before.

No change affecting section 3.