### PR TITLE
Page layout excellence

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -1,3 +1,4 @@
+\clearpage
 \subsection{Methodology}\label{sec:concept_methodology}
 \eucommentary{5-8 pages}
 
@@ -70,6 +71,7 @@
 In the following sections, we explain our concept and the technology on which this
 proposed project builds in more detail.
 \begin{itemize}
+  \itemsep0em
 \item Sections~\fullref{sec:reproducibility} and
   \fullref{sec:reproducibility-challenges} contextualise the proposed work
   within the wide field of reproducibility.

--- a/concept.tex
+++ b/concept.tex
@@ -1,5 +1,3 @@
-\TOWRITE{Min/Hans}{Mention KPIs somewhere?}
-
 \subsection{Methodology}\label{sec:concept_methodology}
 \eucommentary{5-8 pages}
 

--- a/objectives-and-ambition.tex
+++ b/objectives-and-ambition.tex
@@ -225,7 +225,7 @@ in studies that do not make use of Jupyter notebooks.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.8\textwidth]{images/figure1.pdf}
+  \includegraphics[width=1.0\textwidth]{images/figure1.pdf}
   \caption{Figure (\softwarename{figure1.pdf}) which can be reproduced in our explanatory repository example
     \cite{ReproducibilityRepositoryExample2022}. \label{fig:reproducibility-example-covid}}
 \end{figure}


### PR DESCRIPTION
- new page starting at 1.2
- slightly reduced length of itemised list in 1.2.1
- made reproduced figure larger (just to fill the page, and we have the space)

Benefits:
- page 8 contains all of section 1.2.3, and nothing else
- page 9 has the beginning and figure for approach
- science applications end neatly on page 11
- page 12 starts with open source sections
- page 14 starts with TRL, and CEP fits perfectly on rest of the page