### PR TITLE
add correct full names for the BinderHub federation participants

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -415,8 +415,8 @@ The BinderHub Federation is currently composed of three deployments of the Binde
 
 \begin{compactitem}
 \item \url{https://gke.mybinder.org}, operated by the Binder team, and hosted on Google Cloud,
-\item \url{https://ovh.mybinder.org}, operated and hosted by OVH,
-\item \url{https://gesis.mybinder.org}, operated and hosted by GESIS.
+\item \url{https://ovh.mybinder.org}, operated and hosted by OVHcloud,
+\item \url{https://gesis.mybinder.org}, operated and hosted by GESIS (Leibniz Institute for the Social Sciences).
 \end{compactitem}
 
 The focus for this proposal is to improve \repotodocker{}. In particular,


### PR DESCRIPTION
Luckily, for GESIS this fits into a single line at the current
page width...