### PR TITLE
remove unnecessary trailing slashes from urls

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -326,7 +326,7 @@ to motivate and validate our work.
   the size and complexity of marine physics data to be ingested
   to obtain high spatial and temporal resolution of resulting sea bass tracks
   required by scientists researching fish habitats.
-  Access to parallel computing resources through Dask\footnote{\url{https://dask.org/}} on HPC or
+  Access to parallel computing resources through Dask\footnote{\url{https://dask.org}} on HPC or
   Cloud architectures together with access to big data stored next to the
   parallel computing architecture is required to make reproducibility realistic.
   \TheProject will add real value by \textbf{enabling access to HPC from Binder tools} (\taskref{applications}{binder-at-hpc}).
@@ -611,7 +611,7 @@ The Jupyter Project itself and its software ecosystem provides a substantial int
 
 The science applications build on the outcomes of national, Nordic, European and/or international research and
 innovation projects and initiatives. For example, both Ifremer and the University of Oslo are active members of the international
-Pangeo\footnote{\url{https://pangeo.io/}} Big data Geosciences Community. Ifremer, through its co-ownership of Mercator Ocean International,\footnote{\url{https://www.mercator-ocean.eu/}}
+Pangeo\footnote{\url{https://pangeo.io}} Big data Geosciences Community. Ifremer, through its co-ownership of Mercator Ocean International,\footnote{\url{https://www.mercator-ocean.eu}}
  participates in the operation of the Copernicus Marine Environment Monitoring Service (CMEMS),
  a part of Copernicus, the European Union’s Earth Observation Programme and is also actively involved in the
  development of a Digital Twin of the Ocean that will be fully compatible with the Destination Earth (DestinE\footnote{\url{https://digital-strategy.ec.europa.eu/en/policies/destination-earth}})

--- a/impact.tex
+++ b/impact.tex
@@ -393,8 +393,8 @@ findability to the wider community who may not be able to attend workshops.
 These resources will be hosted on free, public hosting services,
 such as GitHub Pages, ReadTheDocs, or YouTube channels, and as much as possible co-developed and co-hosted with existing and
 well-established organisations
-(The Carpentries,\footnote{\url{https://carpentries.org/}} CodeRefinery,\footnote{\url{https://coderefinery.org/}}
-Galaxy Training Network,\footnote{\url{https://training.galaxyproject.org/}} Pangeo,\footnote{\url{http://gallery.pangeo.io/}} etc.).
+(The Carpentries,\footnote{\url{https://carpentries.org}} CodeRefinery,\footnote{\url{https://coderefinery.org}}
+Galaxy Training Network,\footnote{\url{https://training.galaxyproject.org}} Pangeo,\footnote{\url{http://gallery.pangeo.io}} etc.).
 
 We will also disseminate our results through \textbf{publications and conferences}.
 All publications funded by \TheProject will be \textbf{open access},

--- a/objectives-and-ambition.tex
+++ b/objectives-and-ambition.tex
@@ -292,7 +292,7 @@ computational research can achieve this automatic
 reproducibility with little additional effort~\cite{Beg2021}: they use the notebook document as
 the protocol of their analysis (Step 2), which can be executed automatically.
 They can make use of the \textbf{Binder tools} (Section~\ref{sec:opensource}) and/or the
-associated  mybinder.org\footnote{\url{https://mybinder.org/}} service (free and public) that has
+associated  mybinder.org\footnote{\url{https://mybinder.org}} service (free and public) that has
 been designed by the Jupyter team to \textbf{automatically create the appropriate
 software environment} (Step 1) in which the notebook can be executed.
 But different workflows and tools are not as well served, yet.
@@ -342,7 +342,7 @@ We will go beyond the current state of the art by bringing the following selecte
       public Binder instances).
       \emph{Ad hoc} or domain-specific solutions (for instance the usage of cloud optimized
       data formats and associated catalogs such as intake\footnote{\url{https://intake.readthedocs.io/en/latest/index.html}}
-      or STAC\footnote{\url{https://stacspec.org/}} by the Pangeo\footnote{\url{https://pangeo.io/}} Geoscience community)
+      or STAC\footnote{\url{https://stacspec.org}} by the Pangeo\footnote{\url{https://pangeo.io}} Geoscience community)
       have been explored by diverse communities but are technically difficult and not generic enough to be
       adopted by everyone. The Binder software will be extended to \textbf{facilitate data publishing} (see \taskref{applications}{data-publishing}) with
       the plugin of external long-term archive resources and enable the \textbf{publication and reuse of large and complex datasets}.


### PR DESCRIPTION
This makes simple URLs consistent by removing trailing
slashes where unnecessary.  Most URLs already had this,
and it is rather visible via the footnotes.