### PR TITLE
revise impact summary

### DIFF
--- a/impact.tex
+++ b/impact.tex
@@ -571,7 +571,7 @@ This may not be practical or desirable across a variety of domains or
 communities.
 
 Additionally, \textbf{solving software environments is hard},
-and researchers need easy-to-use \textbf{tools} to help.
+and researchers need easy-to-use \textbf{tools}.
 \end{summarybox}
 
 \begin{summarybox}{EXPECTED RESULTS}
@@ -589,7 +589,7 @@ it will be easy for researchers to produce and share results openly and reproduc
 
 \textbf{Exploitation:} We contribute to the \textbf{Binder tools},
 already widely used by \TheProject members and hundreds of thousands world-wide.
-All existing applications, from the \mybinder service to individual users,
+All existing applications, from the \mybinder{} service to individual users,
 immediately and directly benefit from our improvements to the tools.
 Our science applications specifically exploit new features developed by the project.
 
@@ -603,7 +603,6 @@ industrial robotics to quantitative finance.
   be disseminated to potential users and stakeholders through conventional
   academic channels, in-person and remote workshops, websites, video tutorials
   and social media.
-
 \end{summarybox}
 
 \begin{summarybox}{D \& E \& C MEASURES}
@@ -650,7 +649,7 @@ lowers the barrier for adoption, and thereby increases the number, quality, and
 access of reproducible research outputs, as well as increasing public trust in science.
 
 \textbf{Increased re-use of scientific results}: Practical reproducibility
-enables rapid re-use of published results leading to more effective research activities.
+enables rapid re-use of published results leading to more effective research.
 
 \textbf{Democratised science} by lowering the barrier to participation in the research process
 and reproduction of scientific results.

--- a/impact.tex
+++ b/impact.tex
@@ -570,36 +570,8 @@ or aim to solve the whole problem while requiring wholesale adoption of a specif
 This may not be practical or desirable across a variety of domains or
 communities.
 
-Reliably \textbf{reproducing software environments} without requiring adoption of any
-single tool chain -- as fostered by \TheProject{} --
-allows for modular adoption, integrating into policies, practices, etc.
-We will \textbf{lower the practical barrier to reproducibility},
-and thereby increase the adoption of reproducible practices.
-\end{summarybox}
-
-\begin{summarybox}{D \& E \& C MEASURES}
-\eucommentary{What dissemination, exploitation and communication measures will you apply to the results?}
-
-\textbf{Exploitation:} All services based on BinderHub will immediately benefit from the project, improving tools
-already used by hundreds of thousands of users. They will also enable the application of public policies that advocate
-or require reproducibility of scientific outputs. Beyond Binder, underlying tools such as \repotodocker{}
-are used in other parts of the ecosystem to enable the creation of software environments. This is of particular
-interest for several of the science applications in the project, as well as other Jupyter-based platforms
-currently deployed for research and education.
-Such projects will also directly benefit from the improvements to \repotodocker{}.
-
-The QuantStack SME will commercially exploit the improvements to Binder and its technological foundations in areas ranging from
-industrial robotics to quantitative finance.
-
-\textbf{Dissemination:} Results, insights, tools, and guidelines will
-  be disseminated to potential users and stakeholders through conventional
-  academic channels, in-person and remote workshops, websites, video tutorials
-  and social media.
-
-\textbf{Communication:} The media and general public will be informed
-  about the project through news releases, videos, a website, social media,
-  further media engagement, flyers and interviews, with a consistent visual
-  identity.
+Additionally, \textbf{solving software environments is hard},
+and researchers need easy-to-use \textbf{tools} to help.
 \end{summarybox}
 
 \begin{summarybox}{EXPECTED RESULTS}
@@ -611,6 +583,34 @@ it will be easy for researchers to produce and share results openly and reproduc
 
 \textbf{Improved understanding of good practices for reproducibility}: study results, documentation, and workshops will aid researchers and policy makers in understanding the most appropriate practices to adopt in their pursuit of reproducible research.
 
+\end{summarybox}
+\begin{summarybox}{D \& E \& C MEASURES}
+\eucommentary{What dissemination, exploitation and communication measures will you apply to the results?}
+
+\textbf{Exploitation:} We contribute to the \textbf{Binder tools},
+already widely used by \TheProject members and hundreds of thousands world-wide.
+All existing applications, from the \mybinder service to individual users,
+immediately and directly benefit from our improvements to the tools.
+Our science applications specifically exploit new features developed by the project.
+
+The QuantStack SME will \textbf{commercially exploit} the improved Binder tools in areas ranging from
+industrial robotics to quantitative finance.
+
+\end{summarybox}
+
+\begin{summarybox}{D \& E \& C MEASURES}
+\textbf{Dissemination:} Results, insights, tools, and guidelines will
+  be disseminated to potential users and stakeholders through conventional
+  academic channels, in-person and remote workshops, websites, video tutorials
+  and social media.
+
+\end{summarybox}
+
+\begin{summarybox}{D \& E \& C MEASURES}
+\textbf{Communication:} The media and general public will be informed
+  about the project through news releases, videos, a website, social media,
+  further media engagement, flyers and interviews, with a consistent visual
+  identity.
 \end{summarybox}
 
 \begin{summarybox}{TARGET GROUPS}
@@ -647,10 +647,14 @@ What are the expected wider scientific, economic and societal effects of the pro
 
 \textbf{Improved reproducibility of scientific results}: Improving the \emph{ease of use} tools for reproducibility
 lowers the barrier for adoption, and thereby increases the number, quality, and
-access of reproducible research outputs.
+access of reproducible research outputs, as well as increasing public trust in science.
 
 \textbf{Increased re-use of scientific results}: Practical reproducibility
 enables rapid re-use of published results leading to more effective research activities.
+
+\textbf{Democratised science} by lowering the barrier to participation in the research process
+and reproduction of scientific results.
+
 \end{summarybox}
 \end{multicols}
 \clearpage


### PR DESCRIPTION
- allow D & E & C measures to split across the column break (only way I could keep it on the page)
- restrict specific needs to problem statement
- less detail in exploitation
- add democratised science impact