### PR TITLE
Page layout excellence 1 2 12 newpage - please check if we want this 

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -635,6 +635,7 @@ Each represents different stakeholders and expertise in the full lifecycle of re
 ensuring we have the best chance to solve real-world problems
 with a lasting impact for better reproducibility in science.
 
+\newpage
 \subsubsection{Open science practices and implementation}\label{sec:open-science-practices}
 
 \TheProject will make use of open source licensed software, packages and


### PR DESCRIPTION
This change makes 1.2.12 start at the top of page 16:

- beautiful, because it looks quite broken when only the last 3 lines of this
  section are at the top
- nice because the open source section in prominent at the top of a page
- slight downside: some empty space on page 15. Some people may dislike it.

To illustrate: on main
<img width="1849" alt="Screenshot 2022-04-20 at 11 46 47" src="https://user-images.githubusercontent.com/4489119/164200979-94d7d20b-be22-41cb-8877-25b55fb4a1cf.png">

With this PR:

<img width="1843" alt="Screenshot 2022-04-20 at 11 46 28" src="https://user-images.githubusercontent.com/4489119/164201026-a53cd1e9-eb4f-44f5-8696-b84bd85c7c0e.png">

