### PR TITLE
Add terminal "fully operational demonstrators" milestone

### DIFF
--- a/milestones.tex
+++ b/milestones.tex
@@ -128,6 +128,19 @@ TODO:
   as verified by a comparison study with the baseline at the beginning of the project.
   }
 
+  \milestone[
+    id=fully-operational,
+    month=36,
+    wps={impact,applications},
+    verif={Services are running and can be accessed and used by users.},
+    ]
+  {Science demonstrators fully operational}
+  {
+  Science demonstrator services are fully operational, enabled by all the developments of the project,
+  and in active use.
+  The most successful demonstrators are prepared for operation beyond the life of the project.
+  }
+
 \end{milestones}
 
 \milestonetable

--- a/milestones.tex
+++ b/milestones.tex
@@ -136,7 +136,8 @@ TODO:
     ]
   {Science demonstrators fully operational}
   {
-  Science demonstrator services are fully operational, enabled by all the developments of the project,
+  Science demonstrator applications and services are fully operational,
+  enabled by all the developments of the project,
   and in active use.
   The most successful demonstrators are prepared for operation beyond the life of the project.
   }

--- a/risks.tex
+++ b/risks.tex
@@ -1,13 +1,11 @@
+\clearpage
 \subsubsection{Risks and risk management strategy}
 \label{sec:risks}
 
-\ifgrantagreement\else
-An initial risk assessment appears as Table~\ref{risk-table}.
-
-\begin{table}
+\begin{table}[!hb]
 \begin{center}
-\begin{tabular}{m{.15\textwidth}|m{.12\textwidth}|m{.63\textwidth}}\toprule
-  \textbf{Risk} & \textbf{Level without / with mitigation} & \textbf{Mitigation measures}
+\begin{tabular}{>{\raggedright}m{.18\textwidth}|m{.04\textwidth}|m{.7\textwidth}}\toprule
+  \textbf{Risk} (\textbf{likelihood / severity}) & \textbf{WP} & \textbf{Proposed risk-mitigation measures}
   \\\midrule
 
    \multicolumn{3}{c}{
@@ -15,7 +13,8 @@ An initial risk assessment appears as Table~\ref{risk-table}.
    }
    \\\midrule
 
-  Implementing infrastructure that does not match the needs of end users & High/Low &
+  Implementing infrastructure that does not match the needs of end users (\textbf{Low/High}) &
+  all &
   Many of the members of the consortium are themselves end-users with
   a diverse range of needs and points of view; hence the design of
   the proposal and the governance of the project is naturally steered
@@ -27,7 +26,8 @@ An initial risk assessment appears as Table~\ref{risk-table}.
   \\\midrule
 
   Lack of predictability for tasks that are pursued jointly with
-  the community & Medium/Low &
+  the community (\textbf{Low/Medium}) &
+  2, 3 &
   The PIs have a strong experience managing community-developed
   projects where the execution of tasks depends on the availability of
   partners. Some tasks may end up requiring more effort from
@@ -37,29 +37,22 @@ An initial risk assessment appears as Table~\ref{risk-table}.
   fast evolving context. Such random factors will be averaged out over
   the large number of independent tasks.\\\midrule
 
-  Reliance on external software components & Medium/Low & The non-trivial
+  Reliance on external software components (\textbf{Low/Medium}) &
+  2, 3, 4 &
+  The non-trivial
   software components \TheProject relies on are open source. Most are
   very mature
   and supported by an active community, which offers strong long run
   guarantees. The other components could be replaced by alternatives, or
   even taken over by the participants if necessary.
   \\\midrule
-  %\\\midrule
-
-%  \multicolumn{3}{|c|}{
-%    \textit{Use-case risks}
-%  }
-%  \\\midrule
-%
-%  & & \TOWRITE{WP4}{Risks related to use-cases in WP4}
-%  \\\midrule
 
   \multicolumn{3}{c}{
     \textit{Management risks}
   }
   \\\midrule
 
-  Recruitment of highly qualified staff & High/Medium &
+  Recruitment of highly qualified staff (\textbf{Medium/High}) & all &
 
   The majority of positions funded by \TheProject are already hired.
   Only two positions are to be filled, both full-time research software engineers,
@@ -69,14 +62,14 @@ An initial risk assessment appears as Table~\ref{risk-table}.
   to train and mentor new recruits.
  \\\midrule
 
-  Different groups not forming effective team & Medium/Low & The participants have a long
+  Different groups not forming effective team (\textbf{Low/Medium}) & all & The participants have a long
   track record of working collaboratively across multiple
   sites. Thorough planning of project meetings, workshops and
   one-to-one partner visits will facilitate effective teamwork,
   combining in-person and remote collaboration.\\\midrule
   % this also justifies our generous travel budget.
 
-  Partner leaves the consortium & High/Low & If the Grant Agreement requires a replacement
+  Partner leaves the consortium (\textbf{Low/High}) & all & If the Grant Agreement requires a replacement
   in order to achieve the project's objectives, the consortium will invite a new
   relevant partner in. If a replacement is not necessary, the resources and tasks
   of the departing partner will be reallocated to the alternative ones within the
@@ -88,15 +81,14 @@ An initial risk assessment appears as Table~\ref{risk-table}.
   }
   \\\midrule
 
-  Impact of dissemination activities is lower than planned. & Medium/Low &
-
+  Impact of dissemination activities is lower than planned. (\textbf{Low/Medium}) &
+  5 &
   Partners in the consortium have a proven track record at community
   building, training, dissemination, social media communication, and
   outreach, which reduces the risk. The Project Coordinator
   will monitor impact of all dissemination activities. If a deficiency is identified, the consortium
   will propose relevant corrective actions.\\\bottomrule
-  \end{tabular}
+\end{tabular}
 \end{center}
 \caption{\label{risk-table}Initial Risk Assessment}
 \end{table}
-\fi

--- a/workplan.tex
+++ b/workplan.tex
@@ -71,7 +71,7 @@ the usual management work package (\WPref{management}).
 % \TODO{Strange vertical lines at the left of the bottom of table~\ref{sec:deliverables}?}
 
 \subsubsection{Deliverables}\label{sec:deliverables}
-\inputdelivs{9.3cm}%
+\inputdelivs{8.5cm}%
 \input{milestones}
 
 \end{workplan}


### PR DESCRIPTION
- save some precious length with wider layout of WP tables
- updates implementation risk tables to match template
- tweaks to fit risk table on a page with the risk section heading
- fix deliverable table width