### PR TITLE
mention full and growing binderhub federation

### DIFF
--- a/concept.tex
+++ b/concept.tex
@@ -413,13 +413,16 @@ Federation} that collectively host a service running the Binder software
 under the URL \url{https://mybinder.org}. (This is the service we made use of in the example
 of Section~\ref{sec:reproducibility-example}.)
 
-The BinderHub Federation is currently composed of three deployments of the BinderHub software
+The BinderHub Federation is currently composed of four deployments of the BinderHub software
 
 \begin{compactitem}
 \item \url{https://gke.mybinder.org}, operated by the Binder team, and hosted on Google Cloud,
 \item \url{https://ovh.mybinder.org}, operated and hosted by OVHcloud,
-\item \url{https://gesis.mybinder.org}, operated and hosted by GESIS (Leibniz Institute for the Social Sciences).
+\item \url{https://gesis.mybinder.org}, operated and hosted by GESIS (Leibniz Institute for the Social Sciences),
+\item \url{https://turing.mybinder.org}, operated and hosted by The Alan Turing Institute,
 \end{compactitem}
+
+with one additional member in the process of joining at KAUST (King Abdullah University of Science and Technology).
 
 The focus for this proposal is to improve \repotodocker{}. In particular,
 \repotodocker{} solves the software environment challenge (see


### PR DESCRIPTION
- avoid excluding Turing, which is the highest traffic member after GKE, and only paused temporarily
- mention incoming KAUST

doesn't affect pages because of the space we had after 1.2.11. 1.2.9 no longer starts the page, though.